### PR TITLE
Updated workflow to avoid package-lock.json error.

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
When running the github action, there was an error because of a missing package-lock.json. Now yarn is being used instead.